### PR TITLE
Updating gems/dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'berkshelf', '~> 4.0.1'
-# NOTE: berkshelf usually transiently pulls in ridley.
-# TODO: Remove this explicit dependency which pins ridley to v4.4.2.
-gem 'ridley', '~> 4.4.2'
-# TODO: berkshelf 4.x is broken with hashie 3.5.x
-gem 'hashie', '~> 3.4.3'
+gem 'berkshelf'
+gem 'hashie'
 gem 'chefspec'
 gem 'test-kitchen', '~> 1.4.2'
 gem 'kitchen-vagrant'


### PR DESCRIPTION
When running `berks install` on an environment running `ruby 2.7.2` it is failing to run based on what I assume is a compatibility issue with `berkshelf 4.0.1` and `ruby 2.7.2` so going to update gem versions and remove any transient dependencies that are no longer there with the updated gems.